### PR TITLE
add earliest/latest time window filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and sends notifications via native system notification or to [ntfy app](https://
 ### Usage
 
 ```bash
- ./global-entry-slot-notifier -l <location_id> -n <notifier_type> [-t <ntfy_topic>] [-i <duration>] [-b <before_date>]
+ ./global-entry-slot-notifier -l <location_id> -n <notifier_type> [-t <ntfy_topic>] [-i <duration>] [-b <before_date>] [-e <earliest>] [-L <latest>]
 ```
 
 ### Flags
@@ -42,6 +42,8 @@ and sends notifications via native system notification or to [ntfy app](https://
 * `-t`, `--topic`    (required if notifier is app): Specify the ntfy.sh [topic](https://docs.ntfy.sh/) to send notifications to.
 * `-i`, `--interval` (optional): Specify the interval (in seconds, e.g. 30s) at which to check for available appointments. Default is 60s.
 * `-b`, `--before` (optional): Specify a cutoff date (YYYY-MM-DD) to only receive notifications for appointment slots before this date.
+* `-e`, `--earliest` (optional): Only appointments at/after this time (HH:MM, 24-hour).
+* `-L`, `--latest` (optional): Only appointments at/before this time (HH:MM, 24-hour).
 
 ### Examples
 
@@ -55,6 +57,12 @@ and sends notifications via native system notification or to [ntfy app](https://
 
 ```bash
  ./global-entry-slot-notifier -l 5446 -n app -t my-ntfy-topic -b 2025-12-30
+```
+
+3. With time window (only 9am–5pm)
+
+```bash
+ ./global-entry-slot-notifier -l 5446 -n app -t my-ntfy-topic -e 09:00 -L 17:00
 ```
 
 ##### Pick your location id from below to use in flag (above)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -44,17 +44,41 @@ func (m *MockNotifier) Notify(locationID int, startTime string, topic string) er
 	return nil
 }
 
+// ---- Helpers for constructing timestamps used by tests ----
+
+const apiTimeLayout = "2006-01-02T15:04"
+
+// makeTS returns an API-formatted timestamp at (now + dayOffset) with H:M.
+func makeTS(dayOffset int, hour, min int) string {
+	base := time.Now().AddDate(0, 0, dayOffset)
+	t := time.Date(base.Year(), base.Month(), base.Day(), hour, min, 0, 0, base.Location())
+	return t.Format(apiTimeLayout)
+}
+
+// makeJSON is a small helper to marshal appointments.
+func makeJSON(appts []Appointment) string {
+	b, _ := json.Marshal(appts)
+	return string(b)
+}
+
+// defaultOpts returns CheckOptions with no time-of-day filtering.
+func defaultOpts() CheckOptions {
+	return CheckOptions{EarliestMinutes: -1, LatestMinutes: -1}
+}
+
+// -----------------------------------------------------------
+
 func TestAppointmentCheck(t *testing.T) {
-	futureTime := time.Now().Add(24 * time.Hour).Format("2006-01-02T15:04")
+	futureTime := makeTS(1, 10, 30) // 24h+ from now, API layout "2006-01-02T15:04"
 	appointments := []Appointment{
 		{LocationID: 123, StartTimestamp: futureTime},
 	}
-	appointmentsJSON, _ := json.Marshal(appointments)
+	appointmentsJSON := makeJSON(appointments)
 
 	mockClient := &MockHTTPClient{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(string(appointmentsJSON))),
+			Body:       io.NopCloser(strings.NewReader(appointmentsJSON)),
 		},
 		Err: nil,
 	}
@@ -64,7 +88,7 @@ func TestAppointmentCheck(t *testing.T) {
 	topic := "test-topic"
 	beforeDate := time.Now().Add(48 * time.Hour) // Allow appointments within 48 hours
 
-	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate)
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, defaultOpts())
 
 	if !mockNotifier.Called {
 		t.Fatalf("Expected Notify to be called")
@@ -78,12 +102,12 @@ func TestAppointmentCheck(t *testing.T) {
 }
 
 func TestAppointmentCheck_NoAppointments(t *testing.T) {
-	appointmentsJSON, _ := json.Marshal([]Appointment{})
+	appointmentsJSON := makeJSON([]Appointment{})
 
 	mockClient := &MockHTTPClient{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(string(appointmentsJSON))),
+			Body:       io.NopCloser(strings.NewReader(appointmentsJSON)),
 		},
 		Err: nil,
 	}
@@ -93,7 +117,7 @@ func TestAppointmentCheck_NoAppointments(t *testing.T) {
 	topic := "test-topic"
 	beforeDate := time.Now().Add(48 * time.Hour) // Allow appointments within 48 hours
 
-	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate)
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, defaultOpts())
 
 	if mockNotifier.Called {
 		t.Fatalf("Expected Notify not to be called")
@@ -101,16 +125,17 @@ func TestAppointmentCheck_NoAppointments(t *testing.T) {
 }
 
 func TestAppointmentCheck_AppointmentOutsideBeforeDate(t *testing.T) {
-	pastTime := time.Now().Add(72 * time.Hour).Format(time.RFC3339) // 3 days from now
+	// 3 days from now (outside 48h window), using the API layout so it parses.
+	outsideTime := makeTS(3, 9, 0)
 	appointments := []Appointment{
-		{LocationID: 123, StartTimestamp: pastTime},
+		{LocationID: 123, StartTimestamp: outsideTime},
 	}
-	appointmentsJSON, _ := json.Marshal(appointments)
+	appointmentsJSON := makeJSON(appointments)
 
 	mockClient := &MockHTTPClient{
 		Response: &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader(string(appointmentsJSON))),
+			Body:       io.NopCloser(strings.NewReader(appointmentsJSON)),
 		},
 		Err: nil,
 	}
@@ -120,7 +145,7 @@ func TestAppointmentCheck_AppointmentOutsideBeforeDate(t *testing.T) {
 	topic := "test-topic"
 	beforeDate := time.Now().Add(48 * time.Hour) // Only allow appointments within 2 days
 
-	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate)
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, defaultOpts())
 
 	if mockNotifier.Called {
 		t.Fatalf("Expected Notify not to be called for appointments after beforeDate")
@@ -138,7 +163,7 @@ func TestAppointmentCheck_HTTPError(t *testing.T) {
 	topic := "test-topic"
 	beforeDate := time.Now().Add(48 * time.Hour) // Allow appointments within 48 hours
 
-	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate)
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, defaultOpts())
 
 	if mockNotifier.Called {
 		t.Fatalf("Expected Notify not to be called")
@@ -159,7 +184,7 @@ func TestAppointmentCheck_UnmarshalError(t *testing.T) {
 	topic := "test-topic"
 	beforeDate := time.Now().Add(48 * time.Hour) // Allow appointments within 48 hours
 
-	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate)
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, defaultOpts())
 
 	if mockNotifier.Called {
 		t.Fatalf("Expected Notify not to be called")
@@ -168,15 +193,145 @@ func TestAppointmentCheck_UnmarshalError(t *testing.T) {
 
 func TestAppointmentCheckScheduler(t *testing.T) {
 	count := 0
-	appointmentCheck := func() {
+	appointmentCheckFn := func() {
 		count++
 	}
 
-	go appointmentCheckScheduler(1*time.Second, appointmentCheck)
+	go appointmentCheckScheduler(1*time.Second, appointmentCheckFn)
 
 	time.Sleep(3500 * time.Millisecond)
 
 	if count != 3 {
 		t.Errorf("Expected appointmentCheck to be called 3 times, got %d", count)
+	}
+}
+
+// ---------------- New tests for earliest/latest filtering ----------------
+
+func TestAppointmentCheck_EarliestOnly(t *testing.T) {
+	// earliest = 08:00; appointments at 07:00 (filtered) and 09:00 (valid)
+	appts := []Appointment{
+		{LocationID: 1, StartTimestamp: makeTS(1, 7, 0)},
+		{LocationID: 2, StartTimestamp: makeTS(1, 9, 0)},
+	}
+	mockClient := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(makeJSON(appts))),
+		},
+	}
+	mockNotifier := &MockNotifier{}
+	url := "http://example.com"
+	topic := "topic"
+	beforeDate := time.Now().Add(72 * time.Hour)
+
+	opts := CheckOptions{
+		EarliestMinutes: 8 * 60,
+		LatestMinutes:   -1,
+	}
+
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, opts)
+
+	if !mockNotifier.Called {
+		t.Fatalf("Expected Notify to be called for appointment >= earliest")
+	}
+	// Should notify on the first valid (09:00), not the 07:00 one.
+	if mockNotifier.LocationID != 2 {
+		t.Errorf("Expected LocationID 2 (09:00), got %d", mockNotifier.LocationID)
+	}
+}
+
+func TestAppointmentCheck_LatestOnly(t *testing.T) {
+	// latest = 10:00; appointments at 09:30 (valid) then 11:00 (filtered)
+	appts := []Appointment{
+		{LocationID: 10, StartTimestamp: makeTS(1, 9, 30)},
+		{LocationID: 11, StartTimestamp: makeTS(1, 11, 0)},
+	}
+	mockClient := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(makeJSON(appts))),
+		},
+	}
+	mockNotifier := &MockNotifier{}
+	url := "http://example.com"
+	topic := "topic"
+	beforeDate := time.Now().Add(72 * time.Hour)
+
+	opts := CheckOptions{
+		EarliestMinutes: -1,
+		LatestMinutes:   10 * 60,
+	}
+
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, opts)
+
+	if !mockNotifier.Called {
+		t.Fatalf("Expected Notify to be called for appointment <= latest")
+	}
+	if mockNotifier.LocationID != 10 {
+		t.Errorf("Expected LocationID 10 (09:30), got %d", mockNotifier.LocationID)
+	}
+}
+
+func TestAppointmentCheck_BothValidRange(t *testing.T) {
+	// earliest=08:00, latest=10:00; appointments at 07:30 (filtered), 09:00 (valid), 10:30 (filtered)
+	appts := []Appointment{
+		{LocationID: 101, StartTimestamp: makeTS(1, 7, 30)},
+		{LocationID: 102, StartTimestamp: makeTS(1, 9, 0)},
+		{LocationID: 103, StartTimestamp: makeTS(1, 10, 30)},
+	}
+	mockClient := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(makeJSON(appts))),
+		},
+	}
+	mockNotifier := &MockNotifier{}
+	url := "http://example.com"
+	topic := "topic"
+	beforeDate := time.Now().Add(72 * time.Hour)
+
+	opts := CheckOptions{
+		EarliestMinutes: 8 * 60,
+		LatestMinutes:   10 * 60,
+	}
+
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, opts)
+
+	if !mockNotifier.Called {
+		t.Fatalf("Expected Notify to be called for appointment within [earliest, latest]")
+	}
+	if mockNotifier.LocationID != 102 {
+		t.Errorf("Expected LocationID 102 (09:00), got %d", mockNotifier.LocationID)
+	}
+}
+
+func TestAppointmentCheck_BothInvalidRange_NoNotify(t *testing.T) {
+	// earliest=12:00, latest=10:00, impossible to satisfy both; expect no notify
+	appts := []Appointment{
+		{LocationID: 201, StartTimestamp: makeTS(1, 9, 0)},
+		{LocationID: 202, StartTimestamp: makeTS(1, 11, 30)},
+		{LocationID: 203, StartTimestamp: makeTS(1, 13, 0)},
+	}
+	mockClient := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(makeJSON(appts))),
+		},
+	}
+	mockNotifier := &MockNotifier{}
+	url := "http://example.com"
+	topic := "topic"
+	beforeDate := time.Now().Add(72 * time.Hour)
+
+	opts := CheckOptions{
+		EarliestMinutes: 12 * 60,
+		LatestMinutes:   10 * 60,
+	}
+
+	appointmentCheck(url, mockClient, mockNotifier, topic, beforeDate, opts)
+
+	if mockNotifier.Called {
+		t.Fatalf("Expected Notify NOT to be called when latest < earliest")
 	}
 }


### PR DESCRIPTION
## Changes

This commit introduces **time-of-day filtering** for appointment notifications

### Features Added
- Added new CLI optional flags:
  - `--earliest, -e <HH:MM>` → Only appointments **at or after** this time (24-hour format).
  - `--latest, -L <HH:MM>` → Only appointments **at or before** this time (24-hour format).